### PR TITLE
#10 ignore build-in ghost user by default

### DIFF
--- a/src/LdapSyncCommand.php
+++ b/src/LdapSyncCommand.php
@@ -1040,8 +1040,8 @@ class LdapSyncCommand extends \Symfony\Component\Console\Command\Command
                     continue;
                 }
 
-                if ("root" == $gitlabUserName) {
-                    $this->logger->info("Gitlab built-in root user will be ignored.");
+                if ($this->in_array_i($gitlabUserName, ["root", "ghost"])) {
+                    $this->logger->info(sprintf("Gitlab built-in %s user will be ignored.", $gitlabUserName));
                     continue; // The Gitlab root user should never be updated from LDAP.
                 }
 


### PR DESCRIPTION
This commit should fix error message

> [error] Gitlab failure: "namespace.route" can't be blank, "notification_email" can't be blank, "notification_email" is invalid

See [issue](https://github.com/Adambean/gitlab-ce-ldap-sync/issues/10)