### PR TITLE
Add config option specify Gitlab groupname sanitizer separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,16 @@ groupNamesOfExternal:
 
 Default: *null*
 
+##### groupNameSeparator *(string|null)*
+
+Specify a separator for group names.
+
+By default LDAP group names are sanitized before creating the corresponding Gitlab group from them. The default logic is to remove all "unnice" characters. But if you want your group name in Gitlab to be the exact same as in LDAP for example then this separator can help with it.
+
+E.g. `cn=example-group,ou=groups,dc=example,dc=com` -> Default option is to remove the dash from `example-group` so it would be `example group`. By specifying the separator as `-` it would still remain `example-group`.
+
+Default: " "
+
 #### instances *(array)*
 
 Declare one or more Gitlab instances to sync with. Each array key represents the instance name, which can be used later on to only sync with a particular instance (out of multiple) when running this tool.

--- a/config.yml.dist
+++ b/config.yml.dist
@@ -43,6 +43,8 @@ gitlab:
         groupNamesOfAdministrators:     []
         groupNamesOfExternal:           []
 
+        groupNameSeparator:             ''
+
     instances:
         example:
             url:            ~

--- a/src/LdapSyncCommand.php
+++ b/src/LdapSyncCommand.php
@@ -791,9 +791,9 @@ class LdapSyncCommand extends Command
                 }
 
                 if (!isset($config["gitlab"]["options"]["groupNameSeparator"])) {
-                    $addProblem("warning", "gitlab->options->groupNameSeparator missing. (Assuming default ' '.)");
+                    $addProblem("warning", "gitlab->options->groupNameSeparator missing. (Assuming ' '.)");
                     $config["gitlab"]["options"]["groupNameSeparator"] = " ";
-                } elseif (!($config["gitlab"]["options"]["groupnameseparator"] = trim($config["gitlab"]["options"]["groupnameseparator"])))
+                } elseif (!($config["gitlab"]["options"]["groupnameseparator"] = trim($config["gitlab"]["options"]["groupnameseparator"]))) {
                     $addProblem("warning", "gitlab->options->groupNameSeparator not specified. (Assuming ' '.)");
                     $config["gitlab"]["options"]["groupNameSeparator"] = " ";
                 }

--- a/src/LdapSyncCommand.php
+++ b/src/LdapSyncCommand.php
@@ -793,7 +793,7 @@ class LdapSyncCommand extends Command
                 if (!isset($config["gitlab"]["options"]["groupNameSeparator"])) {
                     $addProblem("warning", "gitlab->options->groupNameSeparator missing. (Assuming ' '.)");
                     $config["gitlab"]["options"]["groupNameSeparator"] = " ";
-                } elseif (!($config["gitlab"]["options"]["groupnameseparator"] = trim($config["gitlab"]["options"]["groupnameseparator"]))) {
+                } elseif (!($config["gitlab"]["options"]["groupNameSeparator"] = trim($config["gitlab"]["options"]["groupNameSeparator"]))) {
                     $addProblem("warning", "gitlab->options->groupNameSeparator not specified. (Assuming ' '.)");
                     $config["gitlab"]["options"]["groupNameSeparator"] = " ";
                 }

--- a/src/LdapSyncCommand.php
+++ b/src/LdapSyncCommand.php
@@ -789,6 +789,14 @@ class LdapSyncCommand extends Command
                         }
                     }
                 }
+
+                if (!isset($config["gitlab"]["options"]["groupNameSeparator"])) {
+                    $addProblem("warning", "gitlab->options->groupNameSeparator missing. (Assuming default ' '.)");
+                    $config["gitlab"]["options"]["groupNameSeparator"] = " ";
+                } elseif (!($config["gitlab"]["options"]["groupnameseparator"] = trim($config["gitlab"]["options"]["groupnameseparator"])))
+                    $addProblem("warning", "gitlab->options->groupNameSeparator not specified. (Assuming ' '.)");
+                    $config["gitlab"]["options"]["groupNameSeparator"] = " ";
+                }
             }
             // >> Gitlab options
 
@@ -1264,7 +1272,7 @@ class LdapSyncCommand extends Command
 
         $slugifyGitlabName = new Slugify([
             "regexp"        => "/([^A-Za-z0-9]|-_\. )+/",
-            "separator"     => " ",
+            "separator"     => $config["gitlab"]["options"]["groupNameSeparator"],
             "lowercase"     => false,
             "trim"          => true,
         ]);


### PR DESCRIPTION
Add option to specify Gitlab groupname sanitizer separator.

The default option would remain the same as it currently is - to use a space.

In my use case I use "rough" groupnames as they come from my LDAP. E.g. I have example-group and that would remain to be example-group. Before this PR, it used to remove the dash.