### PR TITLE
fix docker php version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM mlocati/php-extension-installer:latest AS installer
-FROM php:7.4.9-cli-alpine3.12
+FROM php:8.1.33-cli-alpine3.21
 
 COPY --from=installer /usr/bin/install-php-extensions /usr/bin/
 


### PR DESCRIPTION
Fix composer with `composer update`:

```bash
 > [stage-1 8/8] RUN composer install:
0.448 Installing dependencies from lock file (including require-dev)
0.453 Verifying lock file contents can be installed on current platform.
0.473 Your lock file does not contain a compatible set of packages. Please run composer update.
0.473 
0.473   Problem 1
0.473     - symfony/options-resolver is locked to version v7.3.3 and an update of this package was not requested.
0.473     - symfony/options-resolver v7.3.3 requires php >=8.2 -> your php version (8.1.33) does not satisfy that requirement.
0.473   Problem 2
0.473     - symfony/string is locked to version v7.3.3 and an update of this package was not requested.
0.473     - symfony/string v7.3.3 requires php >=8.2 -> your php version (8.1.33) does not satisfy that requirement.
0.473   Problem 3
0.473     - php-http/client-common is locked to version 2.7.2 and an update of this package was not requested.
0.473     - php-http/client-common 2.7.2 requires symfony/options-resolver ~4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0 || ^6.0 || ^7.0 -> satisfiable by symfony/options-resolver[v7.3.3].
0.473     - symfony/options-resolver v7.3.3 requires php >=8.2 -> your php version (8.1.33) does not satisfy that requirement.
0.473 
------
Dockerfile:19
--------------------
  17 |     COPY . .
  18 |     
  19 | >>> RUN composer install
  20 |     
  21 |     CMD ["update-ca-certificates", "&&", "php", "bin/console", "ldap:sync"]
--------------------
ERROR: failed to build: failed to solve: process "/bin/ash -eo pipefail -c composer install" did not complete successfully: exit code: 2
```

And Fixed PHP Version: 

```bash
------                                                                                                                                                                                                                         
 > [stage-1 8/9] RUN composer update:                                                                                                                                                                                          
0.417 Loading composer repositories with package information
0.680 Updating dependencies
0.690 Your requirements could not be resolved to an installable set of packages.
0.690 
0.690   Problem 1
0.690     - Root composer.json requires php >=8.1 but your php version (7.4.9) does not satisfy that requirement.
0.690   Problem 2
0.690     - Root composer.json requires cocur/slugify ^4.6.0 -> satisfiable by cocur/slugify[v4.6.0].
0.690     - cocur/slugify v4.6.0 requires php ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 -> your php version (7.4.9) does not satisfy that requirement.
0.690   Problem 3
0.690     - Root composer.json requires m4tthumphrey/php-gitlab-api ^12.0.0 -> satisfiable by m4tthumphrey/php-gitlab-api[12.0.0].
0.690     - m4tthumphrey/php-gitlab-api 12.0.0 requires php ^8.1 -> your php version (7.4.9) does not satisfy that requirement.
0.690   Problem 4
0.690     - Root composer.json requires monolog/monolog ^3.9.0 -> satisfiable by monolog/monolog[3.9.0].
0.690     - monolog/monolog 3.9.0 requires php >=8.1 -> your php version (7.4.9) does not satisfy that requirement.
0.690   Problem 5
0.690     - Root composer.json requires symfony/console ^6.4.25 -> satisfiable by symfony/console[v6.4.25, v6.4.26].
0.690     - symfony/console[v6.4.25, ..., v6.4.26] require php >=8.1 -> your php version (7.4.9) does not satisfy that requirement.
0.690   Problem 6
0.690     - Root composer.json requires symfony/yaml ^6.4.25 -> satisfiable by symfony/yaml[v6.4.25, v6.4.26].
0.690     - symfony/yaml[v6.4.25, ..., v6.4.26] require php >=8.1 -> your php version (7.4.9) does not satisfy that requirement.
0.690 
------
```