### PR TITLE
feat: Add regex support and group names prefix mapping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,14 @@ Group names "Root" and "Users" will always be ignored because they are built-in 
 
 Default: *null*
 
+##### groupNamesPrefix *(bool|null)*
+
+Specify a prefix for GitLab-related LDAP groups. This prefix will be omitted in the resulting GitLab groups. LDAP groups that do not start with this prefix will not be created in GitLab, but they will still be considered for [groupNamesOfAdministrators](#groupnamesofadministrators-arraynull) and [groupNamesOfExternal](#groupnamesofexternalregex-bool).
+
+For example, if you have an LDAP group `git-project`, and your `groupNamesPrefix` is `git-`, LDAP members of `git-project` will be added to the GitLab group `project`. If you have the LDAP group `admins`, and `groupNamesOfAdministrators` includes `admins`, users in `admins` will be given administrator, but `admins` will not map to a GitLab group since it does not start with the prefix.
+
+Default: *null*
+
 ##### createEmptyGroups *(bool|null)*
 
 Specify whether groups containing no LDAP users should still be created in GitLab.

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Group names "Root" and "Users" will always be ignored because they are built-in 
 
 Default: *null*
 
-##### groupNamesPrefix *(bool|null)*
+##### groupNamesPrefix *(string|null)*
 
 Specify a prefix for GitLab-related LDAP groups. This prefix will be omitted in the resulting GitLab groups. LDAP groups that do not start with this prefix will not be created in GitLab, but they will still be considered for [`groupNamesOfAdministrators`](#groupnamesofadministrators-arraynull) and [`groupNamesOfExternal`](#groupnamesofexternalregex-bool).
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ This section configures how to communicate with your GitLab-CE/EE instance.
 
 #### options
 
+##### userNamesToIgnoreRegex *bool*
+
+Specify whether `userNamesToIgnore` should use regex.
+
 ##### userNamesToIgnore *(array|null)*
 
 Specify a list of user names of which this tool should ignore. (Case-insensitive.)
@@ -245,6 +249,10 @@ userNamesToIgnore:
 User name "root" will always be ignored because this is the built-in GitLab root user. This tool will not attempt to create/delete/sync this user name.
 
 Default: *null*
+
+##### groupNamesToIgnoreRegex *bool*
+
+Specify whether `groupNamesToIgnore` should use regex.
 
 ##### groupNamesToIgnore *(array|null)*
 
@@ -300,6 +308,10 @@ This will not interfere with existing group members, so you can adjust user perm
 
 Default: 30
 
+##### groupNamesOfAdministratorsRegex *bool*
+
+Specify whether `groupNamesOfAdministrators` should use regex.
+
 ##### groupNamesOfAdministrators *(array|null)*
 
 Specify a list of group names of which members should be granted administrator access.
@@ -318,6 +330,10 @@ groupNamesOfAdministrators:
 ```
 
 Default: *null*
+
+##### groupNamesOfExternalRegex *bool*
+
+Specify whether `groupNamesOfExternal` should use regex.
 
 ##### groupNamesOfExternal *(array|null)*
 

--- a/README.md
+++ b/README.md
@@ -224,9 +224,14 @@ This section configures how to communicate with your GitLab-CE/EE instance.
 
 #### options
 
-##### userNamesToIgnoreRegex *bool*
+##### userNamesToIgnoreRegex *(bool|null)*
 
-Specify whether `userNamesToIgnore` should use regex.
+Specify whether [`userNamesToIgnore`](#usernamestoignore-arraynull) should use regex for matching. If enabled, values in `userNamesToIgnore` must be strings containing a valid [PCRE](https://www.php.net/manual/en/book.pcre.php) regular expression.
+
+Example:
+```
+"/.*/i"
+```
 
 ##### userNamesToIgnore *(array|null)*
 
@@ -250,9 +255,14 @@ User name "root" will always be ignored because this is the built-in GitLab root
 
 Default: *null*
 
-##### groupNamesToIgnoreRegex *bool*
+##### groupNamesToIgnoreRegex *(bool|null)*
 
-Specify whether `groupNamesToIgnore` should use regex.
+Specify whether [`groupNamesToIgnore`](#groupnamestoignore-arraynull) should use regex for matching. If enabled, values in `groupNamesToIgnore` must be strings containing a valid [PCRE](https://www.php.net/manual/en/book.pcre.php) regular expression.
+
+Example:
+```
+"/.*/i"
+```
 
 ##### groupNamesToIgnore *(array|null)*
 
@@ -278,9 +288,9 @@ Default: *null*
 
 ##### groupNamesPrefix *(bool|null)*
 
-Specify a prefix for GitLab-related LDAP groups. This prefix will be omitted in the resulting GitLab groups. LDAP groups that do not start with this prefix will not be created in GitLab, but they will still be considered for [groupNamesOfAdministrators](#groupnamesofadministrators-arraynull) and [groupNamesOfExternal](#groupnamesofexternalregex-bool).
+Specify a prefix for GitLab-related LDAP groups. This prefix will be omitted in the resulting GitLab groups. LDAP groups that do not start with this prefix will not be created in GitLab, but they will still be considered for [`groupNamesOfAdministrators`](#groupnamesofadministrators-arraynull) and [`groupNamesOfExternal`](#groupnamesofexternalregex-bool).
 
-For example, if you have an LDAP group `git-project`, and your `groupNamesPrefix` is `git-`, LDAP members of `git-project` will be added to the GitLab group `project`. If you have the LDAP group `admins`, and `groupNamesOfAdministrators` includes `admins`, users in `admins` will be given administrator, but `admins` will not map to a GitLab group since it does not start with the prefix.
+For example, if you have an LDAP group `git-group1`, and your `groupNamesPrefix` is `git-`, LDAP members of `git-group1` will be added to the GitLab group `group1`. If you have the LDAP group `admins`, and `groupNamesOfAdministrators` includes `admins`, users in `admins` will be given administrator, but `admins` will not map to a GitLab group since it does not start with the prefix.
 
 Default: *null*
 
@@ -316,9 +326,14 @@ This will not interfere with existing group members, so you can adjust user perm
 
 Default: 30
 
-##### groupNamesOfAdministratorsRegex *bool*
+##### groupNamesOfAdministratorsRegex *(bool|null)*
 
-Specify whether `groupNamesOfAdministrators` should use regex.
+Specify whether [`groupNamesOfAdministrators`](#groupnamesofadministrators-arraynull) should use regex for matching. If enabled, values in `groupNamesOfAdministrators` must be strings containing a valid [PCRE](https://www.php.net/manual/en/book.pcre.php) regular expression.
+
+Example:
+```
+"/.*/i"
+```
 
 ##### groupNamesOfAdministrators *(array|null)*
 
@@ -341,7 +356,12 @@ Default: *null*
 
 ##### groupNamesOfExternalRegex *bool*
 
-Specify whether `groupNamesOfExternal` should use regex.
+Specify whether [`groupNamesOfExternal`](#groupnamesofexternal-arraynull) should use regex for matching. If enabled, values in `groupNamesOfExternal` must be strings containing a valid [PCRE](https://www.php.net/manual/en/book.pcre.php) regular expression.
+
+Example:
+```
+"/.*/i"
+```
 
 ##### groupNamesOfExternal *(array|null)*
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Requirements for running this tool from a management station:
 * [PHP's LDAP functions](http://php.net/manual/en/book.ldap.php): Usually installed with PHP as standard, but the LDAP module/functions may not be enabled by default.
 * [Composer](https://getcomposer.org/): Available to most Linux distributions via `apt-get` or `yum`/`dnf`, or manually download it as `composer.phar` alongside this tool.
 * LDAP instance: Used for GitLab's authentication. It can (likely) be Microsoft Active Directory, OpenLDAP, 389-DS (including FreeIPA), and any other LDAP system, though **most of my testing is with 389-DS (without FreeIPA)**.
-* [GitLab community edition](https://about.gitlab.com/install/?version=ce) or [GitLab community edition](https://about.gitlab.com/install/?version=ee) self-hosted: This must be configured to authenticate against an LDAP instance already.
+* [GitLab community edition](https://about.gitlab.com/install/?version=ce) or [GitLab enterprise edition](https://about.gitlab.com/install/?version=ee) self-hosted: This must be configured to authenticate against an LDAP instance already.
 
 ## Installing
 
@@ -111,7 +111,7 @@ If your LDAP server does not allow anonymous access (which is a sensible restric
 
 For example: "uid=Administrator,ou=People,dc=example,dc=com"
 
-##### bindPw *(string|null)*
+##### bindPassword *(string|null)*
 
 If your LDAP server does not allow anonymous access (which is a sensible restriction) specify the password to go with the bind distinguished name.
 

--- a/bin/console
+++ b/bin/console
@@ -10,7 +10,7 @@ require_once __DIR__ . "/../vendor/autoload.php";
 
 use Symfony\Component\Console\Application;
 
-use AdamReece\GitlabCeLdapSync\LdapSyncCommand;
+use AdamReece\GitLabCeLdapSync\LdapSyncCommand;
 
 $app = new Application();
 $app->add(new LdapSyncCommand());

--- a/config.yml.dist
+++ b/config.yml.dist
@@ -38,6 +38,8 @@ gitlab:
         groupNamesToIgnoreRegex:            false
         groupNamesToIgnore:                 []
 
+        groupNamesPrefix:                   ''
+
         createEmptyGroups:                  false
         deleteExtraGroups:                  false
         newMemberAccessLevel:               30

--- a/config.yml.dist
+++ b/config.yml.dist
@@ -6,42 +6,47 @@ ldap:
     winCompatibilityMode:   false
 
     server:
-        host:                           ~
-        port:                           ~
-        version:                        3
-        encryption:                     ~
+        host:                               ~
+        port:                               ~
+        version:                            3
+        encryption:                         ~
 
-        bindDn:                         ~
-        bindPassword:                   ~
+        bindDn:                             ~
+        bindPassword:                       ~
 
     queries:
-        baseDn:                         ''
+        baseDn:                             ''
 
-        userDn:                         ''
-        userFilter:                     "(objectClass=inetOrgPerson)"
-        userUniqueAttribute:            "uid"
-        userMatchAttribute:             "uid"
-        userNameAttribute:              "cn"
-        userEmailAttribute:             "mail"
+        userDn:                             ''
+        userFilter:                         "(objectClass=inetOrgPerson)"
+        userUniqueAttribute:                "uid"
+        userMatchAttribute:                 "uid"
+        userNameAttribute:                  "cn"
+        userEmailAttribute:                 "mail"
 
-        groupDn:                        ''
-        groupFilter:                    "(objectClass=groupOfUniqueNames)"
-        groupUniqueAttribute:           "cn"
-        groupMemberAttribute:           "memberUid"
+        groupDn:                            ''
+        groupFilter:                        "(objectClass=groupOfUniqueNames)"
+        groupUniqueAttribute:               "cn"
+        groupMemberAttribute:               "memberUid"
 
 gitlab:
     debug: false
 
     options:
-        userNamesToIgnore:              []
-        groupNamesToIgnore:             []
+        userNamesToIgnoreRegex:             false
+        userNamesToIgnore:                  []
+        groupNamesToIgnoreRegex:            false
+        groupNamesToIgnore:                 []
 
-        createEmptyGroups:              false
-        deleteExtraGroups:              false
-        newMemberAccessLevel:           30
+        createEmptyGroups:                  false
+        deleteExtraGroups:                  false
+        newMemberAccessLevel:               30
 
-        groupNamesOfAdministrators:     []
-        groupNamesOfExternal:           []
+
+        groupNamesOfAdministratorsRegex:    false
+        groupNamesOfAdministrators:         []
+        groupNamesOfExternalRegex:          false
+        groupNamesOfExternal:               []
 
     instances:
         example:

--- a/src/LdapSyncCommand.php
+++ b/src/LdapSyncCommand.php
@@ -58,6 +58,7 @@ use Symfony\Component\Yaml\Yaml;
  *          userNamesToIgnore: non-empty-string[],
  *          groupNamesToIgnoreRegex: bool,
  *          groupNamesToIgnore: non-empty-string[],
+ *          groupNamesPrefix: ?string,
  *          createEmptyGroups: bool,
  *          deleteExtraGroups: bool,
  *          newMemberAccessLevel: int,
@@ -772,6 +773,12 @@ class LdapSyncCommand extends Command
                     }
                 }
 
+                if (!isset($config["gitlab"]["options"]["groupNamesPrefix"])) {
+                    $config["gitlab"]["options"]["groupNamesPrefix"] = null;
+                } elseif ("" === ($config["gitlab"]["options"]["groupNamesPrefix"] = trim((string) $config["gitlab"]["options"]["groupNamesPrefix"]))) {
+                    $config["gitlab"]["options"]["groupNamesPrefix"] = null;
+                }
+
                 if (!isset($config["gitlab"]["options"]["createEmptyGroups"])) {
                     $addProblem("warning", "gitlab->options->createEmptyGroups missing. (Assuming false.)");
                     $config["gitlab"]["options"]["createEmptyGroups"] = false;
@@ -1199,7 +1206,7 @@ class LdapSyncCommand extends Command
                         continue;
                     }
 
-                    if ($this->in_array_combined($ldapUserName, $config["gitlab"]["options"]["userNamesToIgnore"], $config["gitlab"]["config"]["userNamesToIgnoreRegex"])) {
+                    if ($this->in_array_combined($ldapUserName, $config["gitlab"]["options"]["userNamesToIgnore"], $config["gitlab"]["options"]["userNamesToIgnoreRegex"])) {
                         $this->logger?->info(sprintf("User \"%s\" in ignore list.", $ldapUserName));
                         continue;
                     }
@@ -1308,7 +1315,7 @@ class LdapSyncCommand extends Command
                         continue;
                     }
 
-                    if ($this->in_array_combined($ldapGroupName, $config["gitlab"]["options"]["groupNamesToIgnore"], $config["gitlab"]["config"]["groupNamesToIgnoreRegex"])) {
+                    if ($this->in_array_combined($ldapGroupName, $config["gitlab"]["options"]["groupNamesToIgnore"], $config["gitlab"]["options"]["groupNamesToIgnoreRegex"])) {
                         $this->logger?->info(sprintf("Group \"%s\" in ignore list.", $ldapGroupName));
                         continue;
                     }
@@ -1550,9 +1557,20 @@ class LdapSyncCommand extends Command
         ]);
 
         // Convert LDAP group names into a format safe for GitLab's restrictions
+        // Removes prefix if groupNamesPrefix is defined. Skips groups without prefix.
         $ldapGroupsSafe = [];
         foreach ($ldapGroups as $ldapGroupName => $ldapGroupMembers) {
-            $ldapGroupsSafe[$slugifyGitLabName->slugify($ldapGroupName)] = $ldapGroupMembers;
+            $ldapGroupNameNoPrefix = $ldapGroupName;
+            if($config["gitlab"]["options"]["groupNamesPrefix"] !== null) {
+                if(str_starts_with($ldapGroupNameNoPrefix, $config["gitlab"]["options"]["groupNamesPrefix"])) {
+                    $ldapGroupNameNoPrefix = substr($ldapGroupName, strlen($config["gitlab"]["options"]["groupNamesPrefix"]));
+                } else {
+                    $this->logger?->info(sprintf("Group \"%s\" does not begin with gitlab->options->groupNamesPrefix, ignoring for group creation and membership.", $ldapGroupName));
+                    continue;
+                }
+            }
+
+            $ldapGroupsSafe[$slugifyGitLabName->slugify($ldapGroupNameNoPrefix)] = $ldapGroupMembers;
         }
 
         // Connect
@@ -2011,8 +2029,13 @@ class LdapSyncCommand extends Command
                 continue;
             }
 
-            if ($this->in_array_combined($ldapGroupName, $config["gitlab"]["options"]["groupNamesToIgnore"], $config["gitlab"]["options"]["groupNamesToIgnoreRegex"])) {
-                $this->logger?->info(sprintf("Group \"%s\" in ignore list.", $ldapGroupName));
+            $ldapGroupNameWithPrefix = $ldapGroupName;
+            if($config["gitlab"]["options"]["groupNamesPrefix"] !== null) {
+                $ldapGroupNameWithPrefix = $config["gitlab"]["options"]["groupNamesPrefix"] . $ldapGroupNameWithPrefix;
+            }
+
+            if ($this->in_array_combined($ldapGroupNameWithPrefix, $config["gitlab"]["options"]["groupNamesToIgnore"], $config["gitlab"]["options"]["groupNamesToIgnoreRegex"])) {
+                $this->logger?->info(sprintf("Group \"%s\" in ignore list.", $ldapGroupNameWithPrefix));
                 continue;
             }
 
@@ -2071,8 +2094,13 @@ class LdapSyncCommand extends Command
                 continue;
             }
 
-            if ($this->in_array_combined($gitLabGroupName, $config["gitlab"]["options"]["groupNamesToIgnore"], $config["gitlab"]["options"]["groupNamesToIgnoreRegex"])) {
-                $this->logger?->info(sprintf("Group \"%s\" in ignore list.", $gitLabGroupName));
+            $gitLabGroupNameWithPrefix = $gitLabGroupName;
+            if($config["gitlab"]["options"]["groupNamesPrefix"] !== null) {
+                $gitLabGroupNameWithPrefix = $config["gitlab"]["options"]["groupNamesPrefix"] . $gitLabGroupNameWithPrefix;
+            }
+
+            if ($this->in_array_combined($gitLabGroupNameWithPrefix, $config["gitlab"]["options"]["groupNamesToIgnore"], $config["gitlab"]["options"]["groupNamesToIgnoreRegex"])) {
+                $this->logger?->info(sprintf("Group \"%s\" in ignore list.", $gitLabGroupNameWithPrefix));
                 continue;
             }
 
@@ -2168,8 +2196,13 @@ class LdapSyncCommand extends Command
                 continue;
             }
 
-            if ($this->in_array_combined($gitLabGroupName, $config["gitlab"]["options"]["groupNamesToIgnore"], $config["gitlab"]["options"]["groupNamesToIgnoreRegex"])) {
-                $this->logger?->info(sprintf("Group \"%s\" in ignore list.", $gitLabGroupName));
+            $gitLabGroupNameWithPrefix = $gitLabGroupName;
+            if($config["gitlab"]["options"]["groupNamesPrefix"] !== null) {
+                $gitLabGroupNameWithPrefix = $config["gitlab"]["options"]["groupNamesPrefix"] . $gitLabGroupNameWithPrefix;
+            }
+            
+            if ($this->in_array_combined($gitLabGroupNameWithPrefix, $config["gitlab"]["options"]["groupNamesToIgnore"], $config["gitlab"]["options"]["groupNamesToIgnoreRegex"])) {
+                $this->logger?->info(sprintf("Group \"%s\" in ignore list.", $gitLabGroupNameWithPrefix));
                 continue;
             }
 
@@ -2234,8 +2267,13 @@ class LdapSyncCommand extends Command
                 continue;
             }
 
-            if ($this->in_array_combined($gitLabGroupName, $config["gitlab"]["options"]["groupNamesToIgnore"], $config["gitlab"]["options"]["groupNamesToIgnoreRegex"])) {
-                $this->logger?->info(sprintf("Group \"%s\" in ignore list.", $gitLabGroupName));
+            $gitLabGroupNameWithPrefix = $gitLabGroupName;
+            if($config["gitlab"]["options"]["groupNamesPrefix"] !== null) {
+                $gitLabGroupNameWithPrefix = $config["gitlab"]["options"]["groupNamesPrefix"] . $gitLabGroupNameWithPrefix;
+            }
+
+            if ($this->in_array_combined($gitLabGroupNameWithPrefix, $config["gitlab"]["options"]["groupNamesToIgnore"], $config["gitlab"]["options"]["groupNamesToIgnoreRegex"])) {
+                $this->logger?->info(sprintf("Group \"%s\" in ignore list.", $gitLabGroupNameWithPrefix));
                 continue;
             }
 
@@ -2333,8 +2371,13 @@ class LdapSyncCommand extends Command
                         continue;
                     }
 
-                    if ($this->in_array_combined($gitLabUserName, $config["gitlab"]["options"]["userNamesToIgnore"], $config["gitlab"]["options"]["userNamesToIgnoreRegex"])) {
-                        $this->logger?->info(sprintf("User \"%s\" in ignore list.", $gitLabUserName));
+                    $gitLabGroupNameWithPrefix = $gitLabGroupName;
+                    if($config["gitlab"]["options"]["groupNamesPrefix"] !== null) {
+                        $gitLabGroupNameWithPrefix = $config["gitlab"]["options"]["groupNamesPrefix"] . $gitLabGroupNameWithPrefix;
+                    }
+
+                    if ($this->in_array_combined($gitLabGroupNameWithPrefix, $config["gitlab"]["options"]["userNamesToIgnore"], $config["gitlab"]["options"]["userNamesToIgnoreRegex"])) {
+                        $this->logger?->info(sprintf("User \"%s\" in ignore list.", $gitLabGroupNameWithPrefix));
                         continue;
                     }
 
@@ -2430,8 +2473,13 @@ class LdapSyncCommand extends Command
                     continue;
                 }
 
-                if ($this->in_array_combined($gitLabUserName, $config["gitlab"]["options"]["userNamesToIgnore"], $config["gitlab"]["options"]["userNamesToIgnoreRegex"])) {
-                    $this->logger?->info(sprintf("User \"%s\" in ignore list.", $gitLabUserName));
+                $gitLabGroupNameWithPrefix = $gitLabGroupName;
+                if($config["gitlab"]["options"]["groupNamesPrefix"] !== null) {
+                    $gitLabGroupNameWithPrefix = $config["gitlab"]["options"]["groupNamesPrefix"] . $gitLabGroupNameWithPrefix;
+                }
+
+                if ($this->in_array_combined($gitLabGroupNameWithPrefix, $config["gitlab"]["options"]["userNamesToIgnore"], $config["gitlab"]["options"]["userNamesToIgnoreRegex"])) {
+                    $this->logger?->info(sprintf("User \"%s\" in ignore list.", $gitLabGroupNameWithPrefix));
                     continue;
                 }
 

--- a/src/LdapSyncCommand.php
+++ b/src/LdapSyncCommand.php
@@ -54,12 +54,16 @@ use Symfony\Component\Yaml\Yaml;
  *  gitlab: array{
  *      debug: bool,
  *      options: array{
+ *          userNamesToIgnoreRegex: bool,
  *          userNamesToIgnore: non-empty-string[],
+ *          groupNamesToIgnoreRegex: bool,
  *          groupNamesToIgnore: non-empty-string[],
  *          createEmptyGroups: bool,
  *          deleteExtraGroups: bool,
  *          newMemberAccessLevel: int,
+ *          groupNamesOfAdministratorsRegex: bool,
  *          groupNamesOfAdministrators: non-empty-string[],
+ *          groupNamesOfExternalRegex: bool,
  *          groupNamesOfExternal: non-empty-string[],
  *      },
  *      instances: array<non-empty-string, ConfigGitLabArray>,
@@ -732,6 +736,12 @@ class LdapSyncCommand extends Command
                             $addProblem("error", sprintf("gitlab->options->userNamesToIgnore[%d] not specified.", $i));
                             continue;
                         }
+
+                        if($config["gitlab"]["options"]["userNamesToIgnoreRegex"] && @preg_match($userName, "") === false) {
+                            $addProblem("error", sprintf("gitlab->options->userNamesToIgnore[%d] is invalid regex.", $i));
+                            continue;
+                        }
+
                     }
                 }
 
@@ -752,6 +762,11 @@ class LdapSyncCommand extends Command
 
                         if ("" === ($config["gitlab"]["options"]["groupNamesToIgnore"][$i] = trim($groupName))) {
                             $addProblem("error", sprintf("gitlab->options->groupNamesToIgnore[%d] not specified.", $i));
+                            continue;
+                        }
+
+                        if($config["gitlab"]["options"]["groupNamesToIgnoreRegex"] && @preg_match($groupName, "") === false) {
+                            $addProblem("error", sprintf("gitlab->options->groupNamesToIgnore[%d] is invalid regex.", $i));
                             continue;
                         }
                     }
@@ -806,6 +821,11 @@ class LdapSyncCommand extends Command
                             $addProblem("error", sprintf("gitlab->options->groupNamesOfAdministrators[%d] not specified.", $i));
                             continue;
                         }
+
+                        if($config["gitlab"]["options"]["groupNamesOfAdministratorsRegex"] && @preg_match($groupName, "") === false) {
+                            $addProblem("error", sprintf("gitlab->options->groupNamesOfAdministrators[%d] is invalid regex.", $i));
+                            continue;
+                        }
                     }
                 }
 
@@ -826,6 +846,11 @@ class LdapSyncCommand extends Command
 
                         if ("" === ($config["gitlab"]["options"]["groupNamesOfExternal"][$i] = trim($groupName))) {
                             $addProblem("error", sprintf("gitlab->options->groupNamesOfExternal[%d] not specified.", $i));
+                            continue;
+                        }
+
+                        if($config["gitlab"]["options"]["groupNamesOfExternalRegex"] && @preg_match($groupName, "") === false) {
+                            $addProblem("error", sprintf("gitlab->options->groupNamesOfExternal[%d] is invalid regex.", $i));
                             continue;
                         }
                     }
@@ -1174,7 +1199,7 @@ class LdapSyncCommand extends Command
                         continue;
                     }
 
-                    if ($this->in_array_i($ldapUserName, $config["gitlab"]["options"]["userNamesToIgnore"])) {
+                    if ($this->in_array_combined($ldapUserName, $config["gitlab"]["options"]["userNamesToIgnore"], $config["gitlab"]["config"]["userNamesToIgnoreRegex"])) {
                         $this->logger?->info(sprintf("User \"%s\" in ignore list.", $ldapUserName));
                         continue;
                     }
@@ -1283,7 +1308,7 @@ class LdapSyncCommand extends Command
                         continue;
                     }
 
-                    if ($this->in_array_i($ldapGroupName, $config["gitlab"]["options"]["groupNamesToIgnore"])) {
+                    if ($this->in_array_combined($ldapGroupName, $config["gitlab"]["options"]["groupNamesToIgnore"], $config["gitlab"]["config"]["groupNamesToIgnoreRegex"])) {
                         $this->logger?->info(sprintf("Group \"%s\" in ignore list.", $ldapGroupName));
                         continue;
                     }
@@ -1314,16 +1339,18 @@ class LdapSyncCommand extends Command
                         continue;
                     }
 
-                    if ($groupMembersAreAdmin = $this->in_array_i(
+                    if ($groupMembersAreAdmin = $this->in_array_combined(
                         $ldapGroupName,
-                        $config["gitlab"]["options"]["groupNamesOfAdministrators"])
+                        $config["gitlab"]["options"]["groupNamesOfAdministrators"],
+                        $config["gitlab"]["options"]["groupNamesOfAdministratorsRegex"])
                     ) {
                         $this->logger?->info(sprintf("Group \"%s\" members are administrators.", $ldapGroupName));
                     }
 
-                    if ($groupMembersAreExternal = $this->in_array_i(
+                    if ($groupMembersAreExternal = $this->in_array_combined(
                         $ldapGroupName,
-                        $config["gitlab"]["options"]["groupNamesOfExternal"])
+                        $config["gitlab"]["options"]["groupNamesOfExternal"],
+                        $config["gitlab"]["options"]["groupNamesOfExternalRegex"])
                     ) {
                         $this->logger?->info(sprintf("Group \"%s\" members are external.", $ldapGroupName));
                     }
@@ -1401,7 +1428,7 @@ class LdapSyncCommand extends Command
                             continue;
                         }
 
-                        if ($this->in_array_i($ldapGroupMemberName, $config["gitlab"]["options"]["userNamesToIgnore"])) {
+                        if ($this->in_array_combined($ldapGroupMemberName, $config["gitlab"]["options"]["userNamesToIgnore"], $config["gitlab"]["options"]["userNamesToIgnoreRegex"])) {
                             $this->logger?->info(sprintf(
                                 "Group #%d / member #%d: User \"%s\" in ignore list.",
                                 $n,
@@ -1637,7 +1664,7 @@ class LdapSyncCommand extends Command
                 continue;
             }
 
-            if ($this->in_array_i($ldapUserName, $config["gitlab"]["options"]["userNamesToIgnore"])) {
+            if ($this->in_array_combined($ldapUserName, $config["gitlab"]["options"]["userNamesToIgnore"], $config["gitlab"]["options"]["userNamesToIgnoreRegex"])) {
                 $this->logger?->info(sprintf("User \"%s\" in ignore list.", $ldapUserName));
                 continue;
             }
@@ -1754,7 +1781,7 @@ class LdapSyncCommand extends Command
                 continue;
             }
 
-            if ($this->in_array_i($gitLabUserName, $config["gitlab"]["options"]["userNamesToIgnore"])) {
+            if ($this->in_array_combined($gitLabUserName, $config["gitlab"]["options"]["userNamesToIgnore"], $config["gitlab"]["options"]["userNamesToIgnoreRegex"])) {
                 $this->logger?->info(sprintf("User \"%s\" in ignore list.", $gitLabUserName));
                 continue;
             }
@@ -1984,7 +2011,7 @@ class LdapSyncCommand extends Command
                 continue;
             }
 
-            if ($this->in_array_i($ldapGroupName, $config["gitlab"]["options"]["groupNamesToIgnore"])) {
+            if ($this->in_array_combined($ldapGroupName, $config["gitlab"]["options"]["groupNamesToIgnore"], $config["gitlab"]["options"]["groupNamesToIgnoreRegex"])) {
                 $this->logger?->info(sprintf("Group \"%s\" in ignore list.", $ldapGroupName));
                 continue;
             }
@@ -2044,7 +2071,7 @@ class LdapSyncCommand extends Command
                 continue;
             }
 
-            if ($this->in_array_i($gitLabGroupName, $config["gitlab"]["options"]["groupNamesToIgnore"])) {
+            if ($this->in_array_combined($gitLabGroupName, $config["gitlab"]["options"]["groupNamesToIgnore"], $config["gitlab"]["options"]["groupNamesToIgnoreRegex"])) {
                 $this->logger?->info(sprintf("Group \"%s\" in ignore list.", $gitLabGroupName));
                 continue;
             }
@@ -2141,7 +2168,7 @@ class LdapSyncCommand extends Command
                 continue;
             }
 
-            if ($this->in_array_i($gitLabGroupName, $config["gitlab"]["options"]["groupNamesToIgnore"])) {
+            if ($this->in_array_combined($gitLabGroupName, $config["gitlab"]["options"]["groupNamesToIgnore"], $config["gitlab"]["options"]["groupNamesToIgnoreRegex"])) {
                 $this->logger?->info(sprintf("Group \"%s\" in ignore list.", $gitLabGroupName));
                 continue;
             }
@@ -2207,7 +2234,7 @@ class LdapSyncCommand extends Command
                 continue;
             }
 
-            if ($this->in_array_i($gitLabGroupName, $config["gitlab"]["options"]["groupNamesToIgnore"])) {
+            if ($this->in_array_combined($gitLabGroupName, $config["gitlab"]["options"]["groupNamesToIgnore"], $config["gitlab"]["options"]["groupNamesToIgnoreRegex"])) {
                 $this->logger?->info(sprintf("Group \"%s\" in ignore list.", $gitLabGroupName));
                 continue;
             }
@@ -2306,7 +2333,7 @@ class LdapSyncCommand extends Command
                         continue;
                     }
 
-                    if ($this->in_array_i($gitLabUserName, $config["gitlab"]["options"]["userNamesToIgnore"])) {
+                    if ($this->in_array_combined($gitLabUserName, $config["gitlab"]["options"]["userNamesToIgnore"], $config["gitlab"]["options"]["userNamesToIgnoreRegex"])) {
                         $this->logger?->info(sprintf("User \"%s\" in ignore list.", $gitLabUserName));
                         continue;
                     }
@@ -2403,7 +2430,7 @@ class LdapSyncCommand extends Command
                     continue;
                 }
 
-                if ($this->in_array_i($gitLabUserName, $config["gitlab"]["options"]["userNamesToIgnore"])) {
+                if ($this->in_array_combined($gitLabUserName, $config["gitlab"]["options"]["userNamesToIgnore"], $config["gitlab"]["options"]["userNamesToIgnoreRegex"])) {
                     $this->logger?->info(sprintf("User \"%s\" in ignore list.", $gitLabUserName));
                     continue;
                 }
@@ -2515,6 +2542,43 @@ class LdapSyncCommand extends Command
         return in_array($needle, array_map(function ($v) {
             return is_string($v) ? strtolower($v) : $v;
         }, $haystack), true);
+    }
+
+    /**
+     * Checks if a string matches any regular expression in an array.
+     *
+     * @param bool|int|float|string $needle
+     * @param array<mixed>          $haystack
+     *
+     * @return bool
+     */
+    private function in_array_regex($needle, array $haystack): bool
+    {
+        if ("" === $needle) {
+            throw new \UnexpectedValueException("Needle not specified.");
+        }
+
+        foreach ($haystack as $p) {
+            if(@preg_match($p, $needle) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if user is in array with either `in_array_i` or `in_array_regex`.
+     * 
+     * @param bool|int|float|string $needle
+     * @param array<mixed>          $haystack
+     * @param bool                  $useRegex
+     * 
+     * @return bool
+     */
+    private function in_array_combined($needle, array $haystack, bool $useRegex): bool
+    {
+        return $useRegex ? $this->in_array_regex($needle, $haystack) : $this->in_array_i($needle, $haystack);
     }
 
     /**

--- a/src/LdapSyncCommand.php
+++ b/src/LdapSyncCommand.php
@@ -718,6 +718,12 @@ class LdapSyncCommand extends Command
             if (!isset($config["gitlab"]["options"]) || !is_array($config["gitlab"]["options"])) {
                 $addProblem("error", "gitlab->options missing.");
             } else {
+                if (!isset($config["gitlab"]["options"]["userNamesToIgnoreRegex"])) {
+                    $config["gitlab"]["options"]["userNamesToIgnoreRegex"] = false;
+                } elseif (!is_bool($config["gitlab"]["options"]["userNamesToIgnoreRegex"])) {
+                    $addProblem("error", "gitlab->options->userNamesToIgnoreRegex is not a boolean.");
+                }
+
                 if (!isset($config["gitlab"]["options"]["userNamesToIgnore"])) {
                     $addProblem("warning", "gitlab->options->userNamesToIgnore missing. (Assuming none.)");
                     $config["gitlab"]["options"]["userNamesToIgnore"] = [];
@@ -738,12 +744,17 @@ class LdapSyncCommand extends Command
                             continue;
                         }
 
-                        if($config["gitlab"]["options"]["userNamesToIgnoreRegex"] && @preg_match($userName, "") === false) {
+                        if ($config["gitlab"]["options"]["userNamesToIgnoreRegex"] && @preg_match($userName, "") === false) {
                             $addProblem("error", sprintf("gitlab->options->userNamesToIgnore[%d] is invalid regex.", $i));
                             continue;
                         }
-
                     }
+                }
+
+                if (!isset($config["gitlab"]["options"]["groupNamesToIgnoreRegex"])) {
+                    $config["gitlab"]["options"]["groupNamesToIgnoreRegex"] = false;
+                } elseif (!is_bool($config["gitlab"]["options"]["groupNamesToIgnoreRegex"])) {
+                    $addProblem("error", "gitlab->options->groupNamesToIgnoreRegex is not a boolean.");
                 }
 
                 if (!isset($config["gitlab"]["options"]["groupNamesToIgnore"])) {
@@ -766,7 +777,7 @@ class LdapSyncCommand extends Command
                             continue;
                         }
 
-                        if($config["gitlab"]["options"]["groupNamesToIgnoreRegex"] && @preg_match($groupName, "") === false) {
+                        if ($config["gitlab"]["options"]["groupNamesToIgnoreRegex"] && @preg_match($groupName, "") === false) {
                             $addProblem("error", sprintf("gitlab->options->groupNamesToIgnore[%d] is invalid regex.", $i));
                             continue;
                         }
@@ -809,6 +820,12 @@ class LdapSyncCommand extends Command
                     $addProblem("error", "gitlab->options->newMemberAccessLevel is not an integer.");
                 }
 
+                if (!isset($config["gitlab"]["options"]["groupNamesOfAdministratorsRegex"])) {
+                    $config["gitlab"]["options"]["groupNamesOfAdministratorsRegex"] = false;
+                } elseif (!is_bool($config["gitlab"]["options"]["groupNamesOfAdministratorsRegex"])) {
+                    $addProblem("error", "gitlab->options->groupNamesOfAdministratorsRegex is not a boolean.");
+                }
+
                 if (!isset($config["gitlab"]["options"]["groupNamesOfAdministrators"])) {
                     // $addProblem("warning", "gitlab->options->groupNamesOfAdministrators missing. (Assuming none.)");
                     $config["gitlab"]["options"]["groupNamesOfAdministrators"] = [];
@@ -829,11 +846,17 @@ class LdapSyncCommand extends Command
                             continue;
                         }
 
-                        if($config["gitlab"]["options"]["groupNamesOfAdministratorsRegex"] && @preg_match($groupName, "") === false) {
+                        if ($config["gitlab"]["options"]["groupNamesOfAdministratorsRegex"] && @preg_match($groupName, "") === false) {
                             $addProblem("error", sprintf("gitlab->options->groupNamesOfAdministrators[%d] is invalid regex.", $i));
                             continue;
                         }
                     }
+                }
+
+                if (!isset($config["gitlab"]["options"]["groupNamesOfExternalRegex"])) {
+                    $config["gitlab"]["options"]["groupNamesOfExternalRegex"] = false;
+                } elseif (!is_bool($config["gitlab"]["options"]["groupNamesOfExternalRegex"])) {
+                    $addProblem("error", "gitlab->options->groupNamesOfExternalRegex is not a boolean.");
                 }
 
                 if (!isset($config["gitlab"]["options"]["groupNamesOfExternal"])) {
@@ -856,7 +879,7 @@ class LdapSyncCommand extends Command
                             continue;
                         }
 
-                        if($config["gitlab"]["options"]["groupNamesOfExternalRegex"] && @preg_match($groupName, "") === false) {
+                        if ($config["gitlab"]["options"]["groupNamesOfExternalRegex"] && @preg_match($groupName, "") === false) {
                             $addProblem("error", sprintf("gitlab->options->groupNamesOfExternal[%d] is invalid regex.", $i));
                             continue;
                         }
@@ -1561,8 +1584,8 @@ class LdapSyncCommand extends Command
         $ldapGroupsSafe = [];
         foreach ($ldapGroups as $ldapGroupName => $ldapGroupMembers) {
             $ldapGroupNameNoPrefix = $ldapGroupName;
-            if($config["gitlab"]["options"]["groupNamesPrefix"] !== null) {
-                if(str_starts_with($ldapGroupNameNoPrefix, $config["gitlab"]["options"]["groupNamesPrefix"])) {
+            if ($config["gitlab"]["options"]["groupNamesPrefix"] !== null) {
+                if (str_starts_with($ldapGroupNameNoPrefix, $config["gitlab"]["options"]["groupNamesPrefix"])) {
                     $ldapGroupNameNoPrefix = substr($ldapGroupName, strlen($config["gitlab"]["options"]["groupNamesPrefix"]));
                 } else {
                     $this->logger?->info(sprintf("Group \"%s\" does not begin with gitlab->options->groupNamesPrefix, ignoring for group creation and membership.", $ldapGroupName));
@@ -2030,7 +2053,7 @@ class LdapSyncCommand extends Command
             }
 
             $ldapGroupNameWithPrefix = $ldapGroupName;
-            if($config["gitlab"]["options"]["groupNamesPrefix"] !== null) {
+            if ($config["gitlab"]["options"]["groupNamesPrefix"] !== null) {
                 $ldapGroupNameWithPrefix = $config["gitlab"]["options"]["groupNamesPrefix"] . $ldapGroupNameWithPrefix;
             }
 
@@ -2095,7 +2118,7 @@ class LdapSyncCommand extends Command
             }
 
             $gitLabGroupNameWithPrefix = $gitLabGroupName;
-            if($config["gitlab"]["options"]["groupNamesPrefix"] !== null) {
+            if ($config["gitlab"]["options"]["groupNamesPrefix"] !== null) {
                 $gitLabGroupNameWithPrefix = $config["gitlab"]["options"]["groupNamesPrefix"] . $gitLabGroupNameWithPrefix;
             }
 
@@ -2197,7 +2220,7 @@ class LdapSyncCommand extends Command
             }
 
             $gitLabGroupNameWithPrefix = $gitLabGroupName;
-            if($config["gitlab"]["options"]["groupNamesPrefix"] !== null) {
+            if ($config["gitlab"]["options"]["groupNamesPrefix"] !== null) {
                 $gitLabGroupNameWithPrefix = $config["gitlab"]["options"]["groupNamesPrefix"] . $gitLabGroupNameWithPrefix;
             }
             
@@ -2268,7 +2291,7 @@ class LdapSyncCommand extends Command
             }
 
             $gitLabGroupNameWithPrefix = $gitLabGroupName;
-            if($config["gitlab"]["options"]["groupNamesPrefix"] !== null) {
+            if ($config["gitlab"]["options"]["groupNamesPrefix"] !== null) {
                 $gitLabGroupNameWithPrefix = $config["gitlab"]["options"]["groupNamesPrefix"] . $gitLabGroupNameWithPrefix;
             }
 
@@ -2371,13 +2394,8 @@ class LdapSyncCommand extends Command
                         continue;
                     }
 
-                    $gitLabGroupNameWithPrefix = $gitLabGroupName;
-                    if($config["gitlab"]["options"]["groupNamesPrefix"] !== null) {
-                        $gitLabGroupNameWithPrefix = $config["gitlab"]["options"]["groupNamesPrefix"] . $gitLabGroupNameWithPrefix;
-                    }
-
-                    if ($this->in_array_combined($gitLabGroupNameWithPrefix, $config["gitlab"]["options"]["userNamesToIgnore"], $config["gitlab"]["options"]["userNamesToIgnoreRegex"])) {
-                        $this->logger?->info(sprintf("User \"%s\" in ignore list.", $gitLabGroupNameWithPrefix));
+                    if ($this->in_array_combined($gitLabUserName, $config["gitlab"]["options"]["userNamesToIgnore"], $config["gitlab"]["options"]["userNamesToIgnoreRegex"])) {
+                        $this->logger?->info(sprintf("User \"%s\" in ignore list.", $gitLabUserName));
                         continue;
                     }
 
@@ -2473,12 +2491,7 @@ class LdapSyncCommand extends Command
                     continue;
                 }
 
-                $gitLabGroupNameWithPrefix = $gitLabGroupName;
-                if($config["gitlab"]["options"]["groupNamesPrefix"] !== null) {
-                    $gitLabGroupNameWithPrefix = $config["gitlab"]["options"]["groupNamesPrefix"] . $gitLabGroupNameWithPrefix;
-                }
-
-                if ($this->in_array_combined($gitLabGroupNameWithPrefix, $config["gitlab"]["options"]["userNamesToIgnore"], $config["gitlab"]["options"]["userNamesToIgnoreRegex"])) {
+                if ($this->in_array_combined($gitLabUserName, $config["gitlab"]["options"]["userNamesToIgnore"], $config["gitlab"]["options"]["userNamesToIgnoreRegex"])) {
                     $this->logger?->info(sprintf("User \"%s\" in ignore list.", $gitLabGroupNameWithPrefix));
                     continue;
                 }
@@ -2602,12 +2615,12 @@ class LdapSyncCommand extends Command
      */
     private function in_array_regex($needle, array $haystack): bool
     {
-        if ("" === $needle) {
+        if ("" === ($needle = strval($needle))) {
             throw new \UnexpectedValueException("Needle not specified.");
         }
 
         foreach ($haystack as $p) {
-            if(@preg_match($p, $needle) === 1) {
+            if (@preg_match($p, $needle) === 1) {
                 return true;
             }
         }


### PR DESCRIPTION
Hi! This PR resolves the two main issues I had with using this tool for our setup. Feel free to nitpick or let me know if you'd prefer these be accomplished a different way. Neither of the additions should break existing configs or change original behavior if they aren't in use. I'd also like to add nested group support in the future if I have some extra time.

# Regex Support
I have added regex support for `userNamesToIgnore`, `groupNamesToIgnore`, `groupNamesOfAdministrators`, and `groupNamesOfExternal`. There are associated bools for each (e.g. `userNamesToIgnoreRegex`) to toggle this behavior and checks to make sure this doesn't break existing configs.

I added `in_array_regex`, which checks if the needle matches any of the regular expressions in haystack. I then replaced the related `in_array_i` calls with `in_array_combined`, a helper function which chooses between `in_array_i` or `in_array_regex` depending on the config.

It uses `@preg_match` and roughly follows what you described [here](https://github.com/Adambean/gitlab-ce-ldap-sync/issues/1#issuecomment-511570377) in #1. The relevant sections have been added to the README.

# Prefix Mapping
I also added a new config item, `groupNamesPrefix`. This allows for mapping LDAP group names with a defined prefix into GitLab groups without that prefix. It will not create or update membership for groups that don't have the prefix. Checks for group names to ignore, admins, and external still use the original names before removing the prefix and will work for names without the prefix. If no `groupNamesPrefix` is specified, everything will function as normal.

This addresses #36.

# Misc
- Fixed a couple of typos in the README I caught along the way
- Fixed the capitalization in `bin/console` (`GitlabCeLdapSync` -> `GitLabCeLdapSync`) so the script would run

Everything is tested and appears to work, at least in my setup.